### PR TITLE
Made sorting behavior compliant with usort

### DIFF
--- a/src/PhpCollection/SortedSequence.php
+++ b/src/PhpCollection/SortedSequence.php
@@ -41,7 +41,7 @@ class SortedSequence extends AbstractSequence
         $newElements = array();
         foreach ($this->elements as $element) {
             // We insert the new element before the first element that is greater than itself.
-            if ( ! $added && call_user_func($this->sortFunc, $newElement, $element) === -1) {
+            if ( ! $added && (integer) call_user_func($this->sortFunc, $newElement, $element) < 0) {
                 $newElements[] = $newElement;
                 $added = true;
             }
@@ -65,7 +65,7 @@ class SortedSequence extends AbstractSequence
                 foreach ($addedElements as $i => $newElement) {
                     // If the currently looked at $newElement is not smaller than $element, then we can also conclude
                     // that all other new elements are also not smaller than $element as we have ordered them before.
-                    if (call_user_func($this->sortFunc, $newElement, $element) !== -1) {
+                    if ((integer) call_user_func($this->sortFunc, $newElement, $element) > -1) {
                         break;
                     }
 

--- a/tests/PhpCollection/Tests/SortedSequenceTest.php
+++ b/tests/PhpCollection/Tests/SortedSequenceTest.php
@@ -43,7 +43,7 @@ class SortedSequenceTest extends \PHPUnit_Framework_TestCase
                     return -1;
                 }
 
-                return $a > $b ? 1 : -1;
+                return $a - $b;
             }
 
             if (is_integer($b)) {


### PR DESCRIPTION
Hi Johannes,

First of all, thanks for another great PHP library!

I stumbled upon a compliance-issue: according to the `usort` documentation (http://php.net/manual/en/function.usort.php) a callable may return numbers below, equal to and above 0. But the code of `SortedSequence` relies on the return value to be -1, or something else. Since the initial sorting of elements is done using `usort`, I think it would be best to comply to the `usort` in the way it handles return values (and also convert the return value to an integer). This also allows you to use simpler sort functions, like `return $a - $b`.
