### PR TITLE
Added missing use statement

### DIFF
--- a/src/PhpCollection/SequenceInterface.php
+++ b/src/PhpCollection/SequenceInterface.php
@@ -18,6 +18,8 @@
 
 namespace PhpCollection;
 
+use PhpOption\Option;
+
 /**
  * Interface for mutable sequences.
  *


### PR DESCRIPTION
Same change than in the MapInterface yesterday. I missed it in the SequenceInterface but it is still using Option for `first` and `last`
