### PR TITLE
Fix before_script to work with HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ php:
   - hhvm
 
 before_script:
-    - curl -s http://getcomposer.org/installer | php
-    - php composer.phar install --dev
+  - wget http://getcomposer.org/composer.phar
+  - php composer.phar install --dev
 
 script: phpunit --coverage-clover clover
 
 after_success:
-    - curl -sL https://bit.ly/artifact-uploader | php
+  - curl -sL https://bit.ly/artifact-uploader | php
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Before the output of the composer installer would be piped through php. This doesn't work for HHVM (yet?). In the meantime we can just wget `composer.phar` and use that instead.
