### PR TITLE
Fixed the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2-dev"
+            "dev-master": "0.3-dev"
         }
     }
 }


### PR DESCRIPTION
The latest release is `0.3.1`, so master cannot be `0.2.x-dev` for real
