### PR TITLE
Bumped the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.3-dev"
+            "dev-master": "0.4-dev"
         }
     }
 }


### PR DESCRIPTION
Given that you just released 0.4.0, it should be at leats `0.4.x-dev`. I decided to make it `0.5.x-dev` for now, considering that the next version would be a 0.5.0 rather than 0.4.1, but you may disagree with it
